### PR TITLE
Fixes gulp-sass crashes when saving sass files with syntactic errors

### DIFF
--- a/client/gulp/tasks/sass.js
+++ b/client/gulp/tasks/sass.js
@@ -6,6 +6,7 @@ var gulpif       = require('gulp-if');
 var browserSync  = require('browser-sync');
 var autoprefixer = require('gulp-autoprefixer');
 var bulkSass     = require('gulp-sass-bulk-import');
+var plumber      = require('gulp-plumber');
 var handleErrors = require('../util/handle-errors');
 var config       = require('../config');
 
@@ -13,11 +14,13 @@ gulp.task('sass', function () {
 
   return gulp.src(config.styles.src)
 	.pipe(bulkSass())
+    .pipe(plumber())
     .pipe(sass({
       sourceComments: global.isProd ? 'none' : 'map',
       sourceMap: 'sass',
       outputStyle: global.isProd ? 'compressed' : 'nested'
     }))
+    .on('error', handleErrors)
     .pipe(autoprefixer("last 2 versions", "> 1%", "ie 8"))
     .on('error', handleErrors)
     .pipe(gulp.dest(config.styles.dest))

--- a/client/package.json
+++ b/client/package.json
@@ -33,6 +33,7 @@
     "gulp-if": "^1.2.5",
     "gulp-imagemin": "^2.3.0",
     "gulp-notify": "^2.2.0",
+    "gulp-plumber": "^1.2.0",
     "gulp-rename": "^1.2.2",
     "gulp-sass": "^2.0.4",
     "gulp-sass-bulk-import": "^0.3.2",


### PR DESCRIPTION
This is based on [this issue](https://github.com/dlmanning/gulp-sass/issues/44), from the gulp-sass repository.
I hope there is a way to delete the `.on('error', handleErrors)` that is repeated, but for now, this is working.