### PR TITLE
Ticket-info corrected to parse html content

### DIFF
--- a/client/src/app-components/ticket-info.js
+++ b/client/src/app-components/ticket-info.js
@@ -18,8 +18,7 @@ class TicketInfo extends React.Component {
                         <Icon name={(this.props.ticket.language === 'en') ? 'us' : this.props.ticket.language}/>
                     </span>
                 </div>
-                <div className="ticket-info__description">
-                    {this.props.ticket.content}
+                <div className="ticket-info__description"  dangerouslySetInnerHTML={{__html: this.props.ticket.content}}>
                 </div>
 
                 <div className="ticket-info__author">


### PR DESCRIPTION
Html content was not parsed properly to TicketInfo:

![image](https://user-images.githubusercontent.com/12832253/38661435-23794d6c-3e31-11e8-8a49-4c9224917857.png)
