### PR TITLE
build.sh: skip development dependencies

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,7 @@ npm run build
 rm build/index.html
 echo "2/3 Creating api folder..."
 cd ../server
-composer install
+composer install --no-dev
 echo -n > config.php
 mkdir files2
 mv files/.htaccess files2


### PR DESCRIPTION
Development dependencies like PHPUnit shouldn't land into production, which is by the way still vulnerable of https://nvd.nist.gov/vuln/detail/CVE-2017-9841