### PR TITLE
Fix SMTP for servers that don't need auth

### DIFF
--- a/server/libs/MailSender.php
+++ b/server/libs/MailSender.php
@@ -66,10 +66,12 @@ class MailSender {
             $this->mailerInstance->CharSet = 'UTF-8';
 
             $this->mailerInstance->isSMTP();
-            $this->mailerInstance->SMTPAuth = true;
             $this->mailerInstance->Host = $this->mailOptions['smtp-host'];
-            $this->mailerInstance->Username = $this->mailOptions['smtp-user'];
-            $this->mailerInstance->Password = $this->mailOptions['smtp-pass'];
+            if($this->mailerInstance->Username !== '') {
+                $this->mailerInstance->SMTPAuth = true;
+                $this->mailerInstance->Username = $this->mailOptions['smtp-user'];
+                $this->mailerInstance->Password = $this->mailOptions['smtp-pass'];
+            }
             $this->mailerInstance->Timeout = 10;
             $this->mailerInstance->SMTPOptions = [
                 'ssl' => [


### PR DESCRIPTION
Currently this fails against servers that don't need or support AUTH but rely on other means to allow relaying email.