### PR TITLE
Avoid manual parsing of query string using queryString library

### DIFF
--- a/client/src/app-components/ticket-list.js
+++ b/client/src/app-components/ticket-list.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import _ from 'lodash';
 import {connect} from 'react-redux';
+import queryString from 'query-string';
 
 import i18n from 'lib-app/i18n';
 import DateTransformer from 'lib-core/date-transformer';
@@ -85,7 +86,7 @@ class TicketList extends React.Component {
     }
 
     renderMessage() {
-        switch (this.getQueryVariable('message')) {
+        switch (queryString.parse(window.location.search)["message"]) {
             case 'success':
                 return  <Message className="create-ticket-form__message" type="success">{i18n('TICKET_SENT')}</Message>
             case 'fail':
@@ -138,20 +139,6 @@ class TicketList extends React.Component {
         });
 
         return departments;
-    }
-
-    getQueryVariable(variable) {
-        let query = window.location.search.substring(1);
-        let vars = query.split("&");
-
-        for (let i=0; i < vars.length; i++) {
-            let pair = vars[i].split("=");
-            if(pair[0] == variable) {
-                return pair[1];
-            }
-        }
-
-        return false;
     }
 
     getTableHeaders() {


### PR DESCRIPTION
I also checked that no other part of the code is accessing `location.search` without using the `queryString` library afterwards on it.