### PR TITLE
Optimize ticket search

### DIFF
--- a/server/controllers/ticket/search.php
+++ b/server/controllers/ticket/search.php
@@ -107,11 +107,10 @@ class SearchController extends Controller {
     }
 
     public function handler() {
-        ///$t1 = microtime(true);
         $this->ignoreDeparmentFilter = (bool)Controller::request('supervisor');
-        $this->ticketTableExists = RedBean::exec("select table_name from information_schema.tables where table_name = 'ticket';");  /// ~0.602 seconds
-        $this->tagsTableExists = RedBean::exec("select table_name from information_schema.tables where table_name = 'tag_ticket';");
-        $this->ticketEventTableExists = RedBean::exec("select table_name from information_schema.tables where table_name = 'ticketevent';");
+        $this->ticketTableExists = !empty(RedBean::getAll("SHOW TABLES LIKE 'ticket';"));
+        $this->tagsTableExists = !empty(RedBean::getAll("SHOW TABLES LIKE 'tag_ticket';"));
+        $this->ticketEventTableExists = !empty(RedBean::getAll("SHOW TABLES LIKE 'ticketevent';"));
 
         $allowedDepartmentsId = [];
         foreach (Controller::getLoggedUser()->sharedDepartmentList->toArray() as $department) {
@@ -143,7 +142,6 @@ class SearchController extends Controller {
             array_push($ticketList, $ticket->toArray());
         }
         if($this->ticketTableExists){
-            ///echo '(handler: ' . (microtime(true) - $t1) . ")";
             Response::respondSuccess([
                 'tickets' => $ticketList,
                 'pages' => ceil($totalCount / 10),
@@ -152,10 +150,9 @@ class SearchController extends Controller {
         }else{
             Response::respondSuccess([]);
         }
-    } /// The whole function ~1.93762321472166
+    }
 
     public function getSQLQuery($inputs) {
-        ///$sqlQueryTime = microtime(true);
         $taglistQuery = ( $this->tagsTableExists ? " LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id" : '');
         $ticketeventlistQuery = ( $this->ticketEventTableExists ? " LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id" : '');
 
@@ -163,7 +160,6 @@ class SearchController extends Controller {
         $filters = "";
         $this->setQueryFilters($inputs, $filters);
         $query .= $filters . " GROUP BY ticket.id";
-        ///echo "(getSQLQuery: " . (microtime(true) - $sqlQueryTime) . ")";
         return $query;
     }
 

--- a/server/tests/controllers/ticket/searchTest.php
+++ b/server/tests/controllers/ticket/searchTest.php
@@ -240,26 +240,29 @@ class SearchControllerTest extends TestCase {
         );
     }
     public function testQueryWithOrder() {
+        $inputs1 = [
+            'page' => 1
+        ];
+        $inputs2 = [
+            'page' => 1,
+            'query' => 'stark'
+        ];
+        $inputs3 = [
+            'page' => 1,
+            'orderBy' => ['value' => 'closed', 'asc' => 1]
+        ];
         $this->assertEquals(
-            $this->searchController->getSQLQueryWithOrder([
-                'page' => 1
-            ]),
+            $this->searchController->getSQLQueryWithOrder($inputs1, $this->searchController->getSQLQuery($inputs1)),
             "SELECT ticket.id FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) GROUP BY ticket.id ORDER BY ticket.closed asc, ticket.owner_id asc, ticket.unread_staff asc, ticket.date desc, ticket.id desc LIMIT 10 OFFSET 0"
         );
 
         $this->assertEquals(
-            $this->searchController->getSQLQueryWithOrder([
-                'page' => 1,
-                'query' => 'stark'
-            ]),
+            $this->searchController->getSQLQueryWithOrder($inputs2, $this->searchController->getSQLQuery($inputs2)),
             "SELECT ticket.id FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) WHERE  (ticket.title LIKE :query or ticket.content LIKE :query or ticket.ticket_number LIKE :query or (ticketevent.type = 'COMMENT' and ticketevent.content LIKE :query) ) GROUP BY ticket.id ORDER BY CASE WHEN (ticket.ticket_number LIKE :query) THEN 1 WHEN (ticket.title LIKE :queryAtBeginning) THEN 2 WHEN (ticket.title LIKE :query) THEN 3 WHEN ( ticket.content LIKE :query) THEN 4  WHEN (ticketevent.content LIKE :query) THEN 5 END asc, ticket.closed asc, ticket.owner_id asc, ticket.unread_staff asc, ticket.date desc, ticket.id desc LIMIT 10 OFFSET 0"
         );
 
         $this->assertEquals(
-            $this->searchController->getSQLQueryWithOrder([
-                'page' => 1,
-                'orderBy' => ['value' => 'closed', 'asc' => 1]
-            ]),
+            $this->searchController->getSQLQueryWithOrder($inputs3, $this->searchController->getSQLQuery($inputs3)),
             "SELECT ticket.id FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) GROUP BY ticket.id ORDER BY ticket.closed asc,ticket.closed asc, ticket.owner_id asc, ticket.unread_staff asc, ticket.date desc, ticket.id desc LIMIT 10 OFFSET 0"
         );
     }


### PR DESCRIPTION
The `/ticket/search` path was taking a huge amount of time (around 6.5 seconds) for even a trivial load, this was mainly due to redundant calls to the same expensive functions, and a suboptimal group of queries that presumably took a huge time to load because of metadata updates in the `INFORMATION_SCHEMA` database.