### PR TITLE
Fixes /system/get-logs by adding getFetchAs

### DIFF
--- a/server/models/Log.php
+++ b/server/models/Log.php
@@ -27,6 +27,13 @@ class Log extends DataStore {
         ];
     }
 
+    public static function getFetchAs() {
+        return [
+            'authorUser' => 'user',
+            'authorStaff' => 'staff',
+        ];
+    }
+
     public static function createLog($type, $to, $author = null) {
         $session = Session::getInstance();
         $authorName = '';


### PR DESCRIPTION
Previous to this, a call to `/system/get-logs` would have ended up in an internal server error.