### PR TITLE
Changes the order of most calls to assertEquals, minor change in DataStore

### DIFF
--- a/server/models/DataStore.php
+++ b/server/models/DataStore.php
@@ -31,22 +31,16 @@ abstract class DataStore {
 
     public static function getAll() {
         $beanList = RedBean::findAll(static::TABLE);
-        $dataStoreList = new DataStoreList();
-
-        foreach($beanList as $bean) {
-            $dataStoreList->add(new static($bean));
-        }
-
-        return $dataStoreList;
+        return DataStoreList::getList(static::TABLE, $beanList);
     }
-    public static function find($query = '', $matches = []) {
-        $beanList = RedBean::find(static::TABLE, $query, $matches);
+    public static function find($query = '', $bindings = []) {
+        $beanList = RedBean::find(static::TABLE, $query, $bindings);
 
         return DataStoreList::getList(ucfirst(static::TABLE), $beanList);
     }
 
-    public static function findOne($query = '', $matches = []) {
-        $bean = RedBean::findOne(static::TABLE, $query, $matches);
+    public static function findOne($query = '', $bindings = []) {
+        $bean = RedBean::findOne(static::TABLE, $query, $bindings);
 
         return ($bean) ? new static($bean) : new NullDataStore();
     }

--- a/server/tests/controllers/ticket/searchTest.php
+++ b/server/tests/controllers/ticket/searchTest.php
@@ -31,182 +31,183 @@ class SearchControllerTest extends TestCase {
 
     public function testTagsFilter() {
         $this->assertEquals(
+            'FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) GROUP BY ticket.id',
             $this->searchController->getSQLQuery([
                 'tags' => []
-            ]),
-            'FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) GROUP BY ticket.id'
+            ])
         );
 
         $this->assertEquals(
+            'FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) WHERE  ( tag_ticket.tag_id  = 0) GROUP BY ticket.id',
             $this->searchController->getSQLQuery([
                 'tags' => [0]
-            ]),
-            'FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) WHERE  ( tag_ticket.tag_id  = 0) GROUP BY ticket.id'
+            ])
         );
 
         $this->assertEquals(
+            'FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) WHERE  ( tag_ticket.tag_id  = 0 or tag_ticket.tag_id  = 1 or tag_ticket.tag_id  = 2) GROUP BY ticket.id',
             $this->searchController->getSQLQuery([
                 'tags' => [0,1,2]
-            ]),
-            'FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) WHERE  ( tag_ticket.tag_id  = 0 or tag_ticket.tag_id  = 1 or tag_ticket.tag_id  = 2) GROUP BY ticket.id'
+            ])
         );
     }
 
     public function testClosedFilter() {
 
         $this->assertEquals(
+            'FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) GROUP BY ticket.id',
             $this->searchController->getSQLQuery([
                 'closed'=> null
-            ]),
-            'FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) GROUP BY ticket.id'
+            ])
         );
 
 
         $this->assertEquals(
+            'FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) WHERE ticket.closed = 1 GROUP BY ticket.id',
             $this->searchController->getSQLQuery([
                 'closed'=> 1
-            ]),
-            'FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) WHERE ticket.closed = 1 GROUP BY ticket.id'
+            ])
         );
 
         $this->assertEquals(
+            'FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) WHERE ticket.closed = 0 GROUP BY ticket.id',
             $this->searchController->getSQLQuery([
                 'closed'=> '0'
-            ]),
-            'FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) WHERE ticket.closed = 0 GROUP BY ticket.id'
+            ])
         );
     }
     public function testAssignedFilter(){
 
         $this->assertEquals(
+            'FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) GROUP BY ticket.id',
             $this->searchController->getSQLQuery([
                 'assigned'=> null
-            ]),
-            'FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) GROUP BY ticket.id'
+            ])
         );
 
         $this->assertEquals(
+            'FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) WHERE ticket.owner_id IS NULL GROUP BY ticket.id',
             $this->searchController->getSQLQuery([
                 'assigned'=> '0'
-            ]),
-            'FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) WHERE ticket.owner_id IS NULL GROUP BY ticket.id'
+            ])
         );
 
         $this->assertEquals(
+            'FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) WHERE ticket.owner_id IS NOT NULL GROUP BY ticket.id',
             $this->searchController->getSQLQuery([
                 'assigned'=> 1
-            ]),
-            'FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) WHERE ticket.owner_id IS NOT NULL GROUP BY ticket.id'
+            ])
         );
     }
     public function testUnreadStaffFilter() {
         $this->assertEquals(
+            'FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) GROUP BY ticket.id',
             $this->searchController->getSQLQuery([
                 'unreadStaff' => null
-            ]),
-            'FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) GROUP BY ticket.id'
+            ])
         );
 
         $this->assertEquals(
+            'FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) WHERE ticket.unread_staff = 0 GROUP BY ticket.id',
             $this->searchController->getSQLQuery([
                 'unreadStaff' => '0'
-            ]),
-            'FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) WHERE ticket.unread_staff = 0 GROUP BY ticket.id'
+            ])
         );
 
         $this->assertEquals(
+            'FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) WHERE ticket.unread_staff = 1 GROUP BY ticket.id',
             $this->searchController->getSQLQuery([
                 'unreadStaff' => 1
-            ]),
-            'FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) WHERE ticket.unread_staff = 1 GROUP BY ticket.id'
+            ])
         );
     }
 
     public function testdateRangeFilter() {
         $this->assertEquals(
+            'FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) GROUP BY ticket.id',
             $this->searchController->getSQLQuery([
                 'dateRange' => null
-            ]),
-            'FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) GROUP BY ticket.id'
+            ])
         );
 
         $this->assertEquals(
+            'FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) WHERE (ticket.date >= 1 and ticket.date <= 2) GROUP BY ticket.id',
             $this->searchController->getSQLQuery([
                 'dateRange' => [1,2]
-            ]),
-            'FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) WHERE (ticket.date >= 1 and ticket.date <= 2) GROUP BY ticket.id'
+            ])
         );
     }
 
     public function testOwnerFilter() {
         $this->assertEquals(
+            'FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) WHERE (ticket.owner_id = 1 or ticket.owner_id = 2) GROUP BY ticket.id',
             $this->searchController->getSQLQuery([
                 'owners' => [1,2]
-            ]),
-            'FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) WHERE (ticket.owner_id = 1 or ticket.owner_id = 2) GROUP BY ticket.id'
+            ])
         );
 
         $this->assertEquals(
+            'FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) WHERE (ticket.owner_id = 6 or ticket.owner_id = 1 or ticket.owner_id = 9) GROUP BY ticket.id',
             $this->searchController->getSQLQuery([
                 'owners' => [6,1,9]
-            ]),
-            'FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) WHERE (ticket.owner_id = 6 or ticket.owner_id = 1 or ticket.owner_id = 9) GROUP BY ticket.id'
+            ])
         );
 
         $this->assertEquals(
+            'FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) GROUP BY ticket.id',
             $this->searchController->getSQLQuery([
                 'owners' => []
-            ]),
-            'FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) GROUP BY ticket.id'
+            ])
         );
     }
 
     public function testDepartmentsFilter() {
         $this->assertEquals(
+            'FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) WHERE (ticket.author_staff_id = 1 or ticket.department_id = 2 or ticket.department_id = 1 or ticket.department_id = 3) GROUP BY ticket.id',
             $this->searchController->getSQLQuery([
                 'departments' => null,
                 'staffId' => 1,
                 'allowedDepartments' => [2,1,3]
-            ]),
-            'FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) WHERE (ticket.author_staff_id = 1 or ticket.department_id = 2 or ticket.department_id = 1 or ticket.department_id = 3) GROUP BY ticket.id'
+            ])
         );
 
         $this->assertEquals(
+            'FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) WHERE  ( ticket.department_id = 1 ) GROUP BY ticket.id',
             $this->searchController->getSQLQuery([
                 'departments' => [1],
                 'staffId' => 1,
                 'allowedDepartments' => [2,1,3]
-            ]),
-            'FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) WHERE  ( ticket.department_id = 1 ) GROUP BY ticket.id'
+            ])
         );
 
         $this->assertEquals(
+            'FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) WHERE  ( ticket.department_id = 1 or ticket.department_id = 2 or (ticket.author_staff_id = 1 and  ( ticket.department_id = 3 or ticket.department_id = 4)) ) GROUP BY ticket.id',
             $this->searchController->getSQLQuery([
                 'departments' => [1,2,3,4],
                 'staffId' => 1,
                 'allowedDepartments' => [2,1]
-            ]),
-            'FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) WHERE  ( ticket.department_id = 1 or ticket.department_id = 2 or (ticket.author_staff_id = 1 and  ( ticket.department_id = 3 or ticket.department_id = 4)) ) GROUP BY ticket.id'
+            ])
         );
 
         $this->assertEquals(
+            'FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) WHERE (ticket.author_staff_id = 1 and  ( ticket.department_id = 2)) GROUP BY ticket.id',
             $this->searchController->getSQLQuery([
                 'departments' => [2],
                 'staffId' => 1,
                 'allowedDepartments' => [5,6]
-            ]),
-            'FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) WHERE (ticket.author_staff_id = 1 and  ( ticket.department_id = 2)) GROUP BY ticket.id'
+            ])
         );
     }
 
     public function testAuthorsFilter() {
         $this->assertEquals(
+            'FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) GROUP BY ticket.id',
             $this->searchController->getSQLQuery([
                 'authors' => []
-            ]),
-            'FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) GROUP BY ticket.id'
+            ])
         );
         $this->assertEquals(
+            'FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) WHERE  ( ticket.author_staff_id  = 1 or ticket.author_id = 2) GROUP BY ticket.id',
             $this->searchController->getSQLQuery([
                 'authors' => [
                     [
@@ -218,27 +219,26 @@ class SearchControllerTest extends TestCase {
                         'isStaff' => 0
                     ]
                 ]
-            ]),
-            'FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) WHERE  ( ticket.author_staff_id  = 1 or ticket.author_id = 2) GROUP BY ticket.id'
+            ])
         );
     }
 
     public function testQueryFilter() {
         $this->assertEquals(
+            'FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) GROUP BY ticket.id',
             $this->searchController->getSQLQuery([
                 'query' => null
-            ]),
-            'FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) GROUP BY ticket.id'
+            ])
         );
 
         $this->assertEquals(
+            "FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) WHERE  (ticket.title LIKE :query or ticket.content LIKE :query or ticket.ticket_number LIKE :query or (ticketevent.type = 'COMMENT' and ticketevent.content LIKE :query) ) GROUP BY ticket.id",
             $this->searchController->getSQLQuery([
                 'query' => 'hello world'
-            ]),
-            "FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) WHERE  (ticket.title LIKE :query or ticket.content LIKE :query or ticket.ticket_number LIKE :query or (ticketevent.type = 'COMMENT' and ticketevent.content LIKE :query) ) GROUP BY ticket.id"
-
+            ])
         );
     }
+
     public function testQueryWithOrder() {
         $inputs1 = [
             'page' => 1
@@ -252,18 +252,18 @@ class SearchControllerTest extends TestCase {
             'orderBy' => ['value' => 'closed', 'asc' => 1]
         ];
         $this->assertEquals(
-            $this->searchController->getSQLQueryWithOrder($inputs1, $this->searchController->getSQLQuery($inputs1)),
-            "SELECT ticket.id FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) GROUP BY ticket.id ORDER BY ticket.closed asc, ticket.owner_id asc, ticket.unread_staff asc, ticket.date desc, ticket.id desc LIMIT 10 OFFSET 0"
+            "SELECT ticket.id FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) GROUP BY ticket.id ORDER BY ticket.closed asc, ticket.owner_id asc, ticket.unread_staff asc, ticket.date desc, ticket.id desc LIMIT 10 OFFSET 0",
+            $this->searchController->getSQLQueryWithOrder($inputs1, $this->searchController->getSQLQuery($inputs1))
         );
 
         $this->assertEquals(
-            $this->searchController->getSQLQueryWithOrder($inputs2, $this->searchController->getSQLQuery($inputs2)),
-            "SELECT ticket.id FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) WHERE  (ticket.title LIKE :query or ticket.content LIKE :query or ticket.ticket_number LIKE :query or (ticketevent.type = 'COMMENT' and ticketevent.content LIKE :query) ) GROUP BY ticket.id ORDER BY CASE WHEN (ticket.ticket_number LIKE :query) THEN 1 WHEN (ticket.title LIKE :queryAtBeginning) THEN 2 WHEN (ticket.title LIKE :query) THEN 3 WHEN ( ticket.content LIKE :query) THEN 4  WHEN (ticketevent.content LIKE :query) THEN 5 END asc, ticket.closed asc, ticket.owner_id asc, ticket.unread_staff asc, ticket.date desc, ticket.id desc LIMIT 10 OFFSET 0"
+            "SELECT ticket.id FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) WHERE  (ticket.title LIKE :query or ticket.content LIKE :query or ticket.ticket_number LIKE :query or (ticketevent.type = 'COMMENT' and ticketevent.content LIKE :query) ) GROUP BY ticket.id ORDER BY CASE WHEN (ticket.ticket_number LIKE :query) THEN 1 WHEN (ticket.title LIKE :queryAtBeginning) THEN 2 WHEN (ticket.title LIKE :query) THEN 3 WHEN ( ticket.content LIKE :query) THEN 4  WHEN (ticketevent.content LIKE :query) THEN 5 END asc, ticket.closed asc, ticket.owner_id asc, ticket.unread_staff asc, ticket.date desc, ticket.id desc LIMIT 10 OFFSET 0",
+            $this->searchController->getSQLQueryWithOrder($inputs2, $this->searchController->getSQLQuery($inputs2))
         );
 
         $this->assertEquals(
-            $this->searchController->getSQLQueryWithOrder($inputs3, $this->searchController->getSQLQuery($inputs3)),
-            "SELECT ticket.id FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) GROUP BY ticket.id ORDER BY ticket.closed asc,ticket.closed asc, ticket.owner_id asc, ticket.unread_staff asc, ticket.date desc, ticket.id desc LIMIT 10 OFFSET 0"
+            "SELECT ticket.id FROM (ticket LEFT JOIN tag_ticket ON tag_ticket.ticket_id = ticket.id LEFT JOIN ticketevent ON ticketevent.ticket_id = ticket.id) GROUP BY ticket.id ORDER BY ticket.closed asc,ticket.closed asc, ticket.owner_id asc, ticket.unread_staff asc, ticket.date desc, ticket.id desc LIMIT 10 OFFSET 0",
+            $this->searchController->getSQLQueryWithOrder($inputs3, $this->searchController->getSQLQuery($inputs3))
         );
     }
 }

--- a/server/tests/models/DataStoreTest.php
+++ b/server/tests/models/DataStoreTest.php
@@ -38,8 +38,8 @@ class DataStoreTest extends TestCase {
         $this->instance->store();
         $newInstance = new DataStoreMock($this->instance->getBeanInstance());
 
-        $this->assertEquals($newInstance->prop1, 0);
-        $this->assertEquals($newInstance->prop2, 'hello');
+        $this->assertEquals(0, $newInstance->prop1);
+        $this->assertEquals('hello', $newInstance->prop2);
     }
 
     public function testDataStoreCustomData() {
@@ -47,9 +47,9 @@ class DataStoreTest extends TestCase {
             'prop3' => 'EXTRA_DATA'
         ));
 
-        $this->assertEquals($this->instance->prop1, 0);
-        $this->assertEquals($this->instance->prop2, 'hello');
-        $this->assertEquals($this->instance->prop3, 'EXTRA_DATA');
+        $this->assertEquals(0, $this->instance->prop1);
+        $this->assertEquals('hello', $this->instance->prop2);
+        $this->assertEquals('EXTRA_DATA', $this->instance->prop3);
     }
 
     public function testStore() {
@@ -64,7 +64,7 @@ class DataStoreTest extends TestCase {
 
         $dataStoreIntance = DataStoreMock::getDataStore('ID_VALUE');
 
-        $this->assertEquals($dataStoreIntance->prop1, 'TEST_VALUE');
+        $this->assertEquals('TEST_VALUE', $dataStoreIntance->prop1);
 
         $this->assertTrue(RedBean::get('findOne')->hasBeenCalledWithArgs(
             'MOCK_TABLE',

--- a/server/tests/models/MailTemplateTest.php
+++ b/server/tests/models/MailTemplateTest.php
@@ -46,7 +46,7 @@ class MailTemplateTest extends TestCase {
             'userName' => 'Cersei Lannister',
         ]);
 
-        $this->assertEquals($resultSubject, 'Welcoming to cersei@opensupports.com');
+        $this->assertEquals('Welcoming to cersei@opensupports.com', $resultSubject);
         $this->assertContains('Welcome, Cersei Lannister to our team', $resultBody);
     }
 


### PR DESCRIPTION
We were using the wrong (but IMO more natural though) order of the parameters for the `assertEquals` function from the PHP Unit Tests. This lead to confusing messages where the word "Actual" and "Expected" are swapped (this only arises when some test fails, thus why it took so long to discover this).

I also found a more concise replacement for one of the functions in the DataStore.