### PR TITLE
Email reply polling no longer calls undefined method

### DIFF
--- a/server/controllers/system/email-polling.php
+++ b/server/controllers/system/email-polling.php
@@ -83,9 +83,12 @@ class EmailPollingController extends Controller {
 
             try {
                 if($email->isReply()) {
-                    if($email->getTicket()->authorToArray()['email'] === $email->getSender()) {
+                    $ticketAuthor = $email->getTicket()->authorToArray();
+                    if($ticketAuthor['email'] === $email->getSender()) {
                         $session->clearSessionData();
-                        $session->createTicketSession($email->getTicket()->ticketNumber);
+                        $session->createSession($ticketAuthor['id'],
+                                                $ticketAuthor['staff'],
+                                                $email->getTicket()->ticketNumber);
 
                         $commentController->handler();
                     }


### PR DESCRIPTION
As mentioned in PR #880 from 2020  `createTicketSession()` is undefined, causing polling failure when an email reply is received.

Fix attempt by creating a ticket session via `createSession()` using `authorToArray()` data.

Again, feel free to clean up code :)